### PR TITLE
Ignore stale image download completion events

### DIFF
--- a/BFRImageViewController/BFRBackLoadedImageSource.h
+++ b/BFRImageViewController/BFRBackLoadedImageSource.h
@@ -17,6 +17,9 @@ typedef void(^onHiResDownloadComplete)(UIImage * _Nullable,  NSError * _Nullable
 /*! The image that is available for use right away. */
 @property (strong, nonatomic, readonly, nonnull) UIImage *image;
 
+/*! The name of the NSNotificationCenter notification sent once this image has finished loading */
+@property (strong, nonatomic, readonly, nonnull) NSString *completionNotificationName;
+
 /*! This is called on the main thread when the higher resolution image is finished loading. Assign to this if you wish to do any specific logic when the download completes. NOTE: Do not attempt to assign the image to any @c BFRImageContainerViewController, this is done for you. Use this block soley for any other business logic you might have to carry out. */
 @property (copy) onHiResDownloadComplete _Nullable onCompletion;
 

--- a/BFRImageViewController/BFRBackLoadedImageSource.m
+++ b/BFRImageViewController/BFRBackLoadedImageSource.m
@@ -17,6 +17,9 @@
 /*! The high fidelity image that will be loaded in the background and then shown once it's downloaded. */
 @property (strong, nonatomic, nonnull) NSURL *url;
 
+/*! The name of the NSNotificationCenter notification sent once this image has finished loading */
+@property (strong, nonatomic, nonnull) NSString *completionNotificationName;
+
 /*! The image that will show initially. */
 @property (strong, nonatomic, readwrite, nonnull) UIImage *image;
 
@@ -32,6 +35,7 @@
     if (self) {
         self.image = image;
         self.url = url;
+        self.completionNotificationName = [NSString stringWithFormat:@"%@/%@", NOTE_HI_RES_IMG_DOWNLOADED, self.url];
         
         [self loadHighFidelityImage];
     }
@@ -57,7 +61,7 @@
             }
             
             id returnResult = result.alternativeRepresentation ? result.alternativeRepresentation : result.image;
-            [[NSNotificationCenter defaultCenter] postNotificationName:NOTE_HI_RES_IMG_DOWNLOADED object:returnResult];
+            [[NSNotificationCenter defaultCenter] postNotificationName:self.completionNotificationName object:returnResult];
         });
     }];
 }

--- a/BFRImageViewController/BFRImageContainerViewController.m
+++ b/BFRImageViewController/BFRImageContainerViewController.m
@@ -111,8 +111,9 @@
         [self retrieveImageFromURL];
     } else if ([self.imgSrc isKindOfClass:[BFRBackLoadedImageSource class]]) {
         self.assetType = BFRImageAssetTypeRemoteImage;
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleHiResImageDownloaded:) name:NOTE_HI_RES_IMG_DOWNLOADED object:nil];
-        self.imgLoaded = ((BFRBackLoadedImageSource *)self.imgSrc).image;
+        BFRBackLoadedImageSource *backLoadedImageSource = (BFRBackLoadedImageSource *)self.imgSrc;
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleHiResImageDownloaded:) name:backLoadedImageSource.completionNotificationName object:nil];
+        self.imgLoaded = backLoadedImageSource.image;
         [self addImageToScrollView];
     } else {
         self.assetType = BFRImageAssetTypeUnknown;


### PR DESCRIPTION
When using `BFRBackLoadedImageSource`, if the hi-res image was downloading slowly, it was possible that the original
view controller was already dismissed and another controller would receive the global `NOTE_HI_RES_IMG_DOWNLOADED` for the now-stale image request.

For example:

1. Present `BFRImageViewController` for `BFRBackLoadedImageSource` with hi-res image URL `slow.jpg`
2. Dismiss controller
3. Present `BFRImageViewController` for `fast.jpg`
4. Download for `fast.jpg` completes
5. Download for `slow.jpg` completes -> `slow.jpg` replaces `fast.jpg`

The fix attempted here is to make the NSNotificationCenter event names unique by including the URL in the event name.